### PR TITLE
Defining ucs4 as boost::int32_t (ucs4 needs 32-Bit)

### DIFF
--- a/src/include/fcppt/src/utf8/ucs4.hpp
+++ b/src/include/fcppt/src/utf8/ucs4.hpp
@@ -7,12 +7,18 @@
 #ifndef FCPPT_SRC_UTF8_UCS4_HPP_INCLUDED
 #define FCPPT_SRC_UTF8_UCS4_HPP_INCLUDED
 
+#include <fcppt/config/external_begin.hpp>
+#include <boost/cstdint.hpp>
+#include <fcppt/config/external_end.hpp>
+ 
+
 namespace fcppt
 {
 namespace utf8
 {
 
-typedef wchar_t ucs4; // TODO: is this right?
+// typedef wchar_t ucs4; // TODO: is this right? -> No it is not
+typedef boost::int32_t ucs4; 
 
 }
 }


### PR DESCRIPTION
Hi,

UCS-4 has a size of 32-Bit, wchar_t is on GNU/Linux AFAIR 32-Bit, but on Windows it is only 16-Bit
